### PR TITLE
Training script fixes/enhancements

### DIFF
--- a/segnet/compute_bn_statistics.py
+++ b/segnet/compute_bn_statistics.py
@@ -165,7 +165,7 @@ def make_parser():
     p.add_argument('train_model')
     p.add_argument('weights')
     p.add_argument('out_dir')
-    p.add_argument('gpu', type=int)
+    p.add_argument('--gpu', type=int, default=None)
     return p
 
 

--- a/segnet/compute_bn_statistics.py
+++ b/segnet/compute_bn_statistics.py
@@ -165,6 +165,7 @@ def make_parser():
     p.add_argument('train_model')
     p.add_argument('weights')
     p.add_argument('out_dir')
+    p.add_argument('gpu', type=int)
     return p
 
 
@@ -172,6 +173,9 @@ if __name__ == '__main__':
     caffe.set_mode_gpu()
     p = make_parser()
     args = p.parse_args()
+
+    if args.gpu is not None:
+        caffe.set_device(args.gpu)
 
     # build and save testable net
     if not os.path.exists(args.out_dir):

--- a/segnet/run-test
+++ b/segnet/run-test
@@ -60,7 +60,7 @@ spawnSync('python', [
   train,
   weights,
   inferenceDir
-], { stdio: 'inherit' })
+].concat(argv.gpu ? ['--gpu', argv.gpu] : []), { stdio: 'inherit' })
 
 console.log('Running inference.')
 spawnSync('python', [
@@ -69,7 +69,7 @@ spawnSync('python', [
   '--weights', path.join(inferenceDir, 'test_weights.caffemodel'),
   '--classes', classes,
   '--output', output
-], { stdio: 'inherit' })
+].concat(argv.gpu ? ['--gpu', argv.gpu] : []), { stdio: 'inherit' })
 
 fs.copySync(path.join(__dirname, '../results-viewer/dist'), output)
 

--- a/segnet/test_segmentation.py
+++ b/segnet/test_segmentation.py
@@ -26,6 +26,7 @@ parser.add_argument('--weights', type=str, required=True)
 parser.add_argument('--output', type=str, required=True)
 parser.add_argument('--classes', type=str, required=True)
 parser.add_argument('--metrics-only', default=False, action='store_true')
+parser.add_argument('--gpu', type=int)
 args = parser.parse_args()
 
 with open(args.classes) as classes:
@@ -41,6 +42,8 @@ test_data = m.group(1)
 test_data = open(test_data, 'r').readlines()
 
 caffe.set_mode_gpu()
+if args.gpu is not None:
+    caffe.set_device(args.gpu)
 
 net = caffe.Net(args.model,
                 args.weights,

--- a/segnet/test_segmentation.py
+++ b/segnet/test_segmentation.py
@@ -26,7 +26,7 @@ parser.add_argument('--weights', type=str, required=True)
 parser.add_argument('--output', type=str, required=True)
 parser.add_argument('--classes', type=str, required=True)
 parser.add_argument('--metrics-only', default=False, action='store_true')
-parser.add_argument('--gpu', type=int)
+parser.add_argument('--gpu', type=int, default=None)
 args = parser.parse_args()
 
 with open(args.classes) as classes:

--- a/segnet/train
+++ b/segnet/train
@@ -185,8 +185,7 @@ if args.sync:
 
 # Determine which, if any, snapshot we're starting from
 current_iteration = 0
-previous_iteration = None
-previous_snapshot = None
+initial_snapshot = None
 if os.path.isdir(snapshot_dir):
     # If there are snapshots, grab the latest one.
     solver_states = glob.glob(os.path.join(snapshot_dir, args.model + '*.solverstate'))
@@ -196,18 +195,16 @@ if os.path.isdir(snapshot_dir):
     snaps.sort()
     if len(snaps) > 0:
         current_iteration = snaps[-1]
-    if len(snaps) > 1:
-        previous_iteration = snaps[-2]
-        previous_snapshot = solver_states[-2].replace('solverstate', 'caffemodel')
+        initial_snapshot = solver_states[-1].replace('solverstate', 'caffemodel')
 else:
     os.mkdir(snapshot_dir)
 
 # If there was a previous snapshot and it doesn't have an associated test
 # results dir, then run that test before we resume training.
-if previous_iteration is not None:
-    previous_results_dir = previous_snapshot.replace('caffemodel', 'results')
+if initial_snapshot is not None:
+    previous_results_dir = initial_snapshot.replace('caffemodel', 'results')
     if not os.path.exists(previous_results_dir):
-        test_run(previous_snapshot, previous_iteration)
+        test_run(initial_snapshot, current_iteration)
 
 # Run the training/testing loop
 assert args.snapshot > 0

--- a/segnet/train
+++ b/segnet/train
@@ -131,6 +131,14 @@ def test_run(snapshot, iteration):
                  '--train', train_net_path,
                  '--weights', snapshot,
                  '--classes', os.path.join(args.data, 'classes.json')]
+
+    # If we're running on a single GPU, then pass its id to the test-runner
+    # scripts as well. Otherwise, if multiple training runs are happening on
+    # a single machine, they would all run their tests using GPU 0, and fail
+    if not args.cpu and len(args.gpu) == 1:
+        test_args.append('--gpu')
+        test_args.append(','.join(map(str, args.gpu)))
+
     print('Testing: %s' % ' '.join(test_args))
     with open(logfile, 'w') as f:
         exitcode = subprocess.call(test_args, stdout=f, stderr=subprocess.STDOUT)
@@ -171,33 +179,49 @@ with open(train_net_path, 'r') as f:
     batch_size = int(batch_size.group(1))
 train_size = sum(1 for line in open(os.path.join(args.data, 'train.txt')))
 
-
-# Determine which, if any, snapshot we're starting from
-if os.path.isdir(snapshot_dir):
-    # If there are snapshots, grab the latest one.
-    snaps = glob.glob(os.path.join(snapshot_dir, args.model + '*.solverstate'))
-    snaps = map(lambda s: re.search('(\d+)\.solverstate', s), snaps)
-    snaps = map(lambda m: int(m.group(1)), filter(lambda m: m, snaps))
-    snaps.sort()
-    current_iteration = snaps[-1]
-else:
-    os.mkdir(snapshot_dir)
-    current_iteration = 0
-
-
 # Look for a snapshot
 if args.sync:
     subprocess.call(['aws', 's3', 'sync', args.sync, args.output])
 
+# Determine which, if any, snapshot we're starting from
+current_iteration = 0
+previous_iteration = None
+previous_snapshot = None
+if os.path.isdir(snapshot_dir):
+    # If there are snapshots, grab the latest one.
+    solver_states = glob.glob(os.path.join(snapshot_dir, args.model + '*.solverstate'))
+    # parse iteration numbers from the snapshot filenames
+    snaps = map(lambda s: re.search('(\d+)\.solverstate', s), solver_states)
+    snaps = map(lambda m: int(m.group(1)), filter(lambda m: m, snaps))
+    snaps.sort()
+    if len(snaps) > 0:
+        current_iteration = snaps[-1]
+    if len(snaps) > 1:
+        previous_iteration = snaps[-2]
+        previous_snapshot = solver_states[-2].replace('solverstate', 'caffemodel')
+else:
+    os.mkdir(snapshot_dir)
+
+# If there was a previous snapshot and it doesn't have an associated test
+# results dir, then run that test before we resume training.
+if previous_iteration is not None:
+    previous_results_dir = previous_snapshot.replace('caffemodel', 'results')
+    if not os.path.exists(previous_results_dir):
+        test_run(previous_snapshot, previous_iteration)
+
 # Run the training/testing loop
 assert args.snapshot > 0
 while current_iteration < args.iterations:
+    # Train for args.snapshot iterations
     snapshot = snapshot_run(current_iteration, args.snapshot)
+    current_iteration += args.snapshot
+    # Plot the loss curve
     logs_to_plot = glob.glob(os.path.join(args.output, 'train*.log'))
     logs_to_plot = map(lambda p: os.path.relpath(p, args.output), logs_to_plot)
     subprocess.call([plot_log] + logs_to_plot, cwd=args.output)
-    current_iteration += args.snapshot
+    # Test the net
     test_run(snapshot, current_iteration)
+    # Sync to S3
     if args.sync:
         print('Syncing back to %s' % args.sync)
         subprocess.call(['aws', 's3', 'sync', args.output, args.sync])


### PR DESCRIPTION
- When there is a single GPU, pass it along to the test scripts, so that testing happens on the same GPU as training.
- When resuming from a snapshot, if the previous snapshot doesn't have a test, then run the test first.
- At the beginning, sync from S3 to local _before_ looking for a previous snapshot (duh)