### PR TITLE
Switch default from g2.2xlarge to p2.xlarge

### DIFF
--- a/start_instance
+++ b/start_instance
@@ -10,13 +10,13 @@ var argv = require('minimist')(process.argv.slice(2), {
   },
   default: {
     region: 'us-east-1',
-    'instance-type': 'g2.2xlarge',
+    'instance-type': 'p2.xlarge',
     'iam-role': null
   }
 })
 
 if (!argv['ssh-keypath'] || argv._.length !== 1) {
-  console.log('Usage: ' + process.argv[1] + ' --ssh-keypath /path/to/private/key [--instance-type g2.2xlarge] [--region us-east-1] [--iam-role IAM_role] machine_name')
+  console.log('Usage: ' + process.argv[1] + ' --ssh-keypath /path/to/private/key [--instance-type p2.xlarge] [--region us-east-1] [--iam-role IAM_role] machine_name')
   process.exit(1)
 }
 


### PR DESCRIPTION
Currently, the default instance that this script creates is g2.2xlarge, which is a instance optimized for tasks like video encoding. P2 instances use K80 GPUs instead of K520s, which are better suited to machine learning. [This article](http://blog.bitfusion.io/2016/11/03/quick-comparison-of-tensorflow-gpu-performance-on-aws-p2-and-g2-instances) claims that using a P2 over a G2 for training CNNs improved performance per hour 2.42x for a cost per hour increase of 1.39x. Switching from G2 to P2 will reduce time and cost of using skynet-train.